### PR TITLE
Add support for enum module types from ecto_enum lib

### DIFF
--- a/lib/ecto/erd/dbml.ex
+++ b/lib/ecto/erd/dbml.ex
@@ -80,7 +80,6 @@ defmodule Ecto.ERD.DBML do
 
         field ->
           # when the enum field uses ecto_enum lib https://github.com/gjaldon/ecto_enum
-          # which creates enum types on postgres
           case is_enum_module?(field.type) do
             true ->
               [{source, field.name, apply(field.type, :__enums__, [])}]

--- a/lib/ecto/erd/dbml.ex
+++ b/lib/ecto/erd/dbml.ex
@@ -79,10 +79,8 @@ defmodule Ecto.ERD.DBML do
           [{source, name, Map.values(on_dump)}]
 
         field ->
-          raise "#{field}"
-          # when the enum was created using ecto_enum lib
-          # https://github.com/gjaldon/ecto_enum which creates enum types on
-          # postgres
+          # when the enum field uses ecto_enum lib https://github.com/gjaldon/ecto_enum
+          # which creates enum types on postgres
           mapping_other_enum(source, field)
       end)
     end)

--- a/lib/ecto/erd/dbml.ex
+++ b/lib/ecto/erd/dbml.ex
@@ -82,7 +82,7 @@ defmodule Ecto.ERD.DBML do
           # when the enum field uses ecto_enum lib https://github.com/gjaldon/ecto_enum
           case is_enum_module?(type) do
             true ->
-              enum_name = enum_schema(type) <> name
+              enum_name = schema_prefix(type) <> name
 
               [{source, enum_name, apply(field.type, :__enums__, [])}]
 
@@ -131,9 +131,9 @@ defmodule Ecto.ERD.DBML do
     |> Keyword.fetch(:behaviour)
   end
 
-  defp enum_schema(module) do
+  defp schema_prefix(module) do
     if function_exported?(module, :schema, []) do
-      schema = apply(type, :schema, [])
+      schema = apply(module, :schema, [])
 
       if schema == "public", do: "", else: "#{schema}."
     else

--- a/lib/ecto/erd/dbml.ex
+++ b/lib/ecto/erd/dbml.ex
@@ -78,13 +78,13 @@ defmodule Ecto.ERD.DBML do
         %Field{name: name, type: {:parameterized, Ecto.Enum, %{on_dump: on_dump}}} ->
           [{source, name, Map.values(on_dump)}]
 
-        %Field{name: name, type: type} = field ->
+        %Field{name: name, type: type} ->
           # when the enum field uses ecto_enum lib https://github.com/gjaldon/ecto_enum
           case is_enum_module?(type) do
             true ->
               enum_name = schema_prefix(type) <> name
 
-              [{source, enum_name, apply(field.type, :__enums__, [])}]
+              [{source, enum_name, apply(type, :__enums__, [])}]
 
             false ->
               []

--- a/test/ecto/erd_test.exs
+++ b/test/ecto/erd_test.exs
@@ -2,6 +2,20 @@ defmodule Ecto.ERDTest do
   use ExUnit.Case
   alias Ecto.ERD.{DBML, Node, Field}
 
+  defmodule ProjectTypeEnum do
+    use Ecto.Type
+
+    def type, do: :string
+
+    def cast(value), do: {:ok, value}
+
+    def dump(value), do: {:ok, value}
+
+    def load(value), do: {:ok, value}
+
+    def __enums__, do: ~w(private public)
+  end
+
   test inspect(&DBML.enums_mapping/1) do
     result =
       [
@@ -49,7 +63,8 @@ defmodule Ecto.ERDTest do
             Field.new(%{
               name: :status,
               type: {:parameterized, Ecto.Enum, Ecto.Enum.init(values: [:live, :closed])}
-            })
+            }),
+            Field.new(%{name: :type, type: ProjectTypeEnum})
           ]
         }
       ]
@@ -60,6 +75,7 @@ defmodule Ecto.ERDTest do
              ["credentials", :flow] => {"flow", ["complex", "simple"]},
              ["invitations", :flow] => {"flow", ["complex", "simple"]},
              ["projects", :status] => {"projects_status", ["closed", "live"]},
+             ["projects", :type] => {"type", ["private", "public"]},
              ["users", :status] => {"users_status", ["active", "invited", "suspended"]}
            }
   end


### PR DESCRIPTION
* Generates enum module types when defined using [ecto_enum](https://github.com/gjaldon/ecto_enum) lib
* Concatenates schema prefix with enum names (if there is)
  * e.g. `student_journey_candidate_area.payment_method_enum` 

To install from this branch:

```elixir
{:ecto_erd, "~> 0.4", git: "git@github.com:betrybe/ecto_erd.git", branch: "add-support-to-ecto_enum-lib-fields", only: :dev}
```